### PR TITLE
[^p^] tag output fix on locales with comma as decimal point

### DIFF
--- a/core/model/modx/modresponse.class.php
+++ b/core/model/modx/modresponse.class.php
@@ -106,10 +106,10 @@ class modResponse {
 
             $totalTime= (microtime(true) - $this->modx->startTime);
             $queryTime= $this->modx->queryTime;
-            $queryTime= sprintf("%2.4f s", $queryTime);
             $queries= isset ($this->modx->executedQueries) ? $this->modx->executedQueries : 0;
-            $totalTime= sprintf("%2.4f s", $totalTime);
             $phpTime= $totalTime - $queryTime;
+            $queryTime= sprintf("%2.4f s", $queryTime);
+            $totalTime= sprintf("%2.4f s", $totalTime);
             $phpTime= sprintf("%2.4f s", $phpTime);
             $source= $this->modx->resourceGenerated ? "database" : "cache";
             $this->modx->resource->_output= str_replace("[^q^]", $queries, $this->modx->resource->_output);


### PR DESCRIPTION
### What does it do ?

The order of certain lines changed in order to avoid subtraction between float and string variables.
### Why is it needed ?

Without these changes [^p^] tag produced wrong results on locales which use comma as decimal point  (For example, 'ru_RU.utf8')
### Related issue(s)/PR(s)

fixes #12474
